### PR TITLE
feat: Add Linux AppImage CI workflow, introduce versioned artifacts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,37 @@
+name: Linux AppImage Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y qt6-multimedia-dev libqt6opengl6-dev ffmpeg wget libfuse2
+
+    - name: Build and Package AppImage
+      run: |
+        chmod +x deploy/build_appimage.sh
+        ./deploy/build_appimage.sh
+
+    - name: Get Version
+      id: get_version
+      run: |
+        VERSION=$(grep -m 1 -oP '(?<=\[)\d+\.\d+\.\d+(?=\])' CHANGELOG.md)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: DubInstante_linux_${{ steps.get_version.outputs.version }}
+        path: DubInstante_linux_*.AppImage

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,8 +43,15 @@ jobs:
         copy build\Release\DubInstante.exe dist\
         windeployqt --release --no-translations --compiler-runtime --multimedia dist\DubInstante.exe
 
+    - name: Get Version
+      id: get_version
+      shell: bash
+      run: |
+        VERSION=$(grep -m 1 -oP '(?<=\[)\d+\.\d+\.\d+(?=\])' CHANGELOG.md)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: DubInstante-Windows
+        name: DubInstante_windows_${{ steps.get_version.outputs.version }}
         path: dist/

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -659,8 +659,6 @@ void MainWindow::keyPressEvent(QKeyEvent *event) {
       return;
     }
   }
-}
-else {
+
   QMainWindow::keyPressEvent(event);
-}
 }


### PR DESCRIPTION
This pull request introduces improvements to the build and release automation for both Linux and Windows platforms, and includes a minor code cleanup in the Qt GUI event handler. The most significant changes are the addition of a Linux AppImage build workflow and enhancements to the artifact naming convention to include version numbers.

**CI/CD Improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/linux.yml`) to automate building and packaging the application as a Linux AppImage, including dependency installation and artifact upload with versioned naming.
* Updated the Windows CI workflow (`.github/workflows/windows.yml`) to extract the version number from `CHANGELOG.md` and use it in the uploaded artifact's name, improving traceability of builds.

**Code Cleanup:**

* Simplified the `keyPressEvent` method in `src/gui/MainWindow.cpp` by removing unnecessary `else` and braces, making the code cleaner and easier to follow.