### PR TITLE
fix: separate Debian and Arch AppImages to resolve GStreamer crash (closes #7)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Build and Package AppImage
       run: |
-        bash deploy/build_appimage.sh
+        bash deploy/build_appimage.sh debian
 
     - name: Get Version
       id: get_version
@@ -41,8 +41,47 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: DubInstante_linux_${{ steps.get_version.outputs.version }}
-        path: DubInstante_linux_*.AppImage
+        name: DubInstante_debian_${{ steps.get_version.outputs.version }}
+        path: DubInstante_debian_*.AppImage
+
+  build-arch:
+    name: Arch Linux Build
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+    env:
+      APPIMAGE_EXTRACT_AND_RUN: '1'
+      ARCH: x86_64
+    steps:
+    - name: Install dependencies
+      run: |
+        pacman -Syu --noconfirm
+        pacman -S --noconfirm --needed \
+          git cmake wget pkgconf patchelf \
+          qt6-base qt6-multimedia qt6-multimedia-ffmpeg \
+          ffmpeg mesa libglvnd alsa-lib libpulse xcb-util-cursor
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Mark workspace as safe for git
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Build and Package AppImage
+      run: |
+        bash deploy/build_appimage.sh arch
+
+    - name: Get Version
+      id: get_version
+      run: |
+        VERSION=$(grep -m 1 "## \[" CHANGELOG.md | sed -n 's/.*\[\([0-9.]*\)\].*/\1/p')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: DubInstante_arch_${{ steps.get_version.outputs.version }}
+        path: DubInstante_arch_*.AppImage
 
   build-windows:
     name: Windows Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
     env:
       APPIMAGE_EXTRACT_AND_RUN: '1'
       ARCH: x86_64
+      NO_STRIP: '1'
     steps:
     - name: Install dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **DubInstante** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-07-13
+
+### Fixed
+- **Arch Linux Crash (#7)**: Fixed the segmentation fault with `GStreamer-CRITICAL` errors on Arch-based distros (Arch, EndeavourOS, Manjaro) by splitting the Linux release into two AppImages. The new `DubInstante_arch_<version>.AppImage` is built on Arch Linux against current system libraries and uses the Qt Multimedia FFmpeg backend (no GStreamer bundled).
+
+### Changed
+- **Linux Artifact Rename**: The Ubuntu-built AppImage is now named `DubInstante_debian_<version>.AppImage` (previously `DubInstante_linux_<version>.AppImage`). Update any scripts downloading by the old name.
+
 ## [0.11.0] - 2026-03-31
 
 ### Fixed

--- a/deploy/build_appimage.sh
+++ b/deploy/build_appimage.sh
@@ -3,13 +3,14 @@ set -e
 
 # --- Configuration ---
 APP_NAME="DubInstante"
+FLAVOR="${1:-debian}"
 BUILD_DIR="build_release"
 DIST_DIR="dist_appimage"
 DESKTOP_FILE="deploy/dubinstante.desktop"
 
 # Extract version from CHANGELOG.md (e.g., [0.3.4])
 export VERSION=$(grep -m 1 "## \[" CHANGELOG.md | sed -n 's/.*\[\([0-9.]*\)\].*/\1/p')
-echo "--- Building $APP_NAME version $VERSION ---"
+echo "--- Building $APP_NAME version $VERSION ($FLAVOR) ---"
 
 # --- Tools ---
 LINUXDEPLOY="linuxdeploy-x86_64.AppImage"
@@ -64,7 +65,7 @@ export EXTRA_QT_PLUGINS="multimedia"
     --output appimage
 
 # --- 4. Custom Rename ---
-FINAL_NAME="${APP_NAME}_linux_${VERSION}.AppImage"
+FINAL_NAME="${APP_NAME}_${FLAVOR}_${VERSION}.AppImage"
 echo "--- Finalizing: $FINAL_NAME ---"
 mv DubInstante*.AppImage "$FINAL_NAME"
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -65,7 +65,7 @@ DubInstante/
 │   ├── en/README.md              # This file
 │   └── fr/README.md              # French version
 └── .github/workflows/
-    └── main.yml                  # CI: Windows build + AppImage
+    └── main.yml                  # CI: Windows build + Linux AppImages (debian/arch)
 ```
 
 ---
@@ -433,13 +433,17 @@ Pre-built binaries are available from the **Actions** tab (CI artifact: `DubInst
 
 ### Linux
 
-The AppImage version of the application is available from the **Actions** tab (CI artifact: `DubInstante-Linux`).
+Two AppImage builds are available from the **Actions** tab:
+
+- `DubInstante_debian_<version>` — built on Ubuntu 22.04, for Debian/Ubuntu-family distros (Debian, Ubuntu, Mint...).
+- `DubInstante_arch_<version>` — built on Arch Linux against current system libraries, for Arch-based and other rolling distros (Arch, EndeavourOS, Manjaro...). Requires a similarly up-to-date glibc.
 
 
 ### AppImage
 
 ```bash
-./deploy/build_appimage.sh
+./deploy/build_appimage.sh          # debian flavor (default)
+./deploy/build_appimage.sh arch     # arch flavor
 ```
 
 ### Android App

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -65,7 +65,7 @@ DubInstante/
 │   ├── en/README.md              # Version anglaise
 │   └── fr/README.md              # Ce fichier
 └── .github/workflows/
-    └── main.yml                  # CI : build Windows + AppImage
+    └── main.yml                  # CI : build Windows + AppImages Linux (debian/arch)
 ```
 
 ---
@@ -432,12 +432,16 @@ L'application au format zip est disponible depuis l'onglet **Actions** (artefact
 
 ### Linux
 
-L'application au format AppImage est disponible depuis l'onglet **Actions** (artefact CI : `DubInstante-Linux`).
+Deux builds AppImage sont disponibles depuis l'onglet **Actions** :
+
+- `DubInstante_debian_<version>` — compilée sur Ubuntu 22.04, pour les distributions de la famille Debian/Ubuntu (Debian, Ubuntu, Mint...).
+- `DubInstante_arch_<version>` — compilée sur Arch Linux avec les bibliothèques système à jour, pour les distributions basées sur Arch et autres rolling releases (Arch, EndeavourOS, Manjaro...). Nécessite une glibc aussi récente.
 
 ### AppImage
 
 ```bash
-./deploy/build_appimage.sh
+./deploy/build_appimage.sh          # variante debian (par défaut)
+./deploy/build_appimage.sh arch     # variante arch
 ```
 
 ### Application Android


### PR DESCRIPTION
## Summary

- Fixes #7 — Arch/EndeavourOS segfault caused by GStreamer library mismatch between the Ubuntu-built AppImage bundle and the host's rolling GStreamer (1.28)
- Ships two Linux artifacts: `DubInstante_debian_<version>.AppImage` (Ubuntu 22.04) and `DubInstante_arch_<version>.AppImage` (built in `archlinux:base-devel` against current Arch libs)
- The Arch build uses `qt6-multimedia-ffmpeg` — zero GStreamer bundled, eliminating the version mismatch entirely
- Renames `DubInstante_linux_*` → `DubInstante_debian_*` — update any scripts downloading by the old name

## Changes

- `deploy/build_appimage.sh` — optional `FLAVOR` arg (`debian` default / `arch`)
- `.github/workflows/main.yml` — new `build-arch` job + renamed debian artifact
- `docs/en/README.md`, `docs/fr/README.md` — document both artifacts
- `CHANGELOG.md` — 0.11.1 entry

## Test plan

- [ ] CI: both `DubInstante_debian_*` and `DubInstante_arch_*` artifacts appear in Actions
- [ ] Arch bundle: no `libgst*` files, `libffmpegmediaplugin.so` present
- [ ] Ask GabGamesAndCode (issue #7 reporter) to test on EndeavourOS — no segfault

🤖 Generated with [Claude Code](https://claude.com/claude-code)